### PR TITLE
Refactor custom identifiers

### DIFF
--- a/cpp/opaque-rust.cpp
+++ b/cpp/opaque-rust.cpp
@@ -804,7 +804,7 @@ struct OpaqueClientRegistrationFinishParams final {
   ::rust::String password;
   ::rust::String registration_response;
   ::rust::String client_registration;
-  ::rust::String client_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;
@@ -838,7 +838,7 @@ struct OpaqueClientLoginFinishParams final {
   ::rust::String client_login;
   ::rust::String credential_response;
   ::rust::String password;
-  ::rust::String client_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;
@@ -861,7 +861,7 @@ struct OpaqueClientLoginFinishResult final {
 #define CXXBRIDGE1_STRUCT_OpaqueServerRegistrationStartParams
 struct OpaqueServerRegistrationStartParams final {
   ::rust::String server_setup;
-  ::rust::String client_identifier;
+  ::rust::String credential_identifier;
   ::rust::String registration_request;
 
   using IsRelocatable = ::std::true_type;
@@ -874,7 +874,8 @@ struct OpaqueServerLoginStartParams final {
   ::rust::String server_setup;
   ::rust::Vec<::rust::String> password_file;
   ::rust::String credential_request;
-  ::rust::String client_identifier;
+  ::rust::String credential_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;

--- a/cpp/opaque-rust.h
+++ b/cpp/opaque-rust.h
@@ -736,7 +736,7 @@ struct OpaqueClientRegistrationFinishParams final {
   ::rust::String password;
   ::rust::String registration_response;
   ::rust::String client_registration;
-  ::rust::String client_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;
@@ -770,7 +770,7 @@ struct OpaqueClientLoginFinishParams final {
   ::rust::String client_login;
   ::rust::String credential_response;
   ::rust::String password;
-  ::rust::String client_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;
@@ -793,7 +793,7 @@ struct OpaqueClientLoginFinishResult final {
 #define CXXBRIDGE1_STRUCT_OpaqueServerRegistrationStartParams
 struct OpaqueServerRegistrationStartParams final {
   ::rust::String server_setup;
-  ::rust::String client_identifier;
+  ::rust::String credential_identifier;
   ::rust::String registration_request;
 
   using IsRelocatable = ::std::true_type;
@@ -806,7 +806,8 @@ struct OpaqueServerLoginStartParams final {
   ::rust::String server_setup;
   ::rust::Vec<::rust::String> password_file;
   ::rust::String credential_request;
-  ::rust::String client_identifier;
+  ::rust::String credential_identifier;
+  ::rust::Vec<::rust::String> client_identifier;
   ::rust::Vec<::rust::String> server_identifier;
 
   using IsRelocatable = ::std::true_type;

--- a/cpp/react-native-opaque.cpp
+++ b/cpp/react-native-opaque.cpp
@@ -83,6 +83,29 @@ namespace NativeOpaque
 		return result;
 	}
 
+	::rust::Vec<::rust::String> getIdentifier(jsi::Runtime &rt, jsi::Object &obj, const char *name)
+	{
+		auto result = ::rust::Vec<::rust::String>();
+		if (!obj.hasProperty(rt, "identifiers"))
+			return result;
+		auto identsProp = obj.getProperty(rt, "identifiers");
+		if (!identsProp.isObject())
+		{
+			throw jsi::JSError(rt, "\"identifiers\" must be an object");
+		}
+		auto identsObj = identsProp.asObject(rt);
+		if (identsObj.hasProperty(rt, name))
+		{
+			auto prop = identsObj.getProperty(rt, name);
+			if (!prop.isString())
+			{
+				throw jsi::JSError(rt, "identifier \"" + std::string(name) + "\" must be a string");
+			}
+			result.push_back(std::string(prop.asString(rt).utf8(rt)));
+		}
+		return result;
+	}
+
 	jsi::Value clientRegistrationFinish(jsi::Runtime &rt, jsi::Value &input)
 	{
 		auto obj = input.asObject(rt);
@@ -91,8 +114,8 @@ namespace NativeOpaque
 			.password = getProp(rt, obj, "password").utf8(rt),
 			.registration_response = getProp(rt, obj, "registrationResponse").utf8(rt),
 			.client_registration = getProp(rt, obj, "clientRegistration").utf8(rt),
-			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
-			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
+			.client_identifier = getIdentifier(rt, obj, "client"),
+			.server_identifier = getIdentifier(rt, obj, "server"),
 		};
 
 		auto finish = opaque_client_registration_finish(params);
@@ -119,8 +142,8 @@ namespace NativeOpaque
 			.client_login = getProp(rt, obj, "clientLogin").utf8(rt),
 			.credential_response = getProp(rt, obj, "credentialResponse").utf8(rt),
 			.password = getProp(rt, obj, "password").utf8(rt),
-			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
-			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
+			.client_identifier = getIdentifier(rt, obj, "client"),
+			.server_identifier = getIdentifier(rt, obj, "server"),
 		};
 		auto result = opaque_client_login_finish(params);
 		if (result == nullptr)
@@ -168,8 +191,8 @@ namespace NativeOpaque
 			.password_file = getOptional(rt, obj, "passwordFile"),
 			.credential_request = getProp(rt, obj, "credentialRequest").utf8(rt),
 			.credential_identifier = getProp(rt, obj, "credentialIdentifier").utf8(rt),
-			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
-			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
+			.client_identifier = getIdentifier(rt, obj, "client"),
+			.server_identifier = getIdentifier(rt, obj, "server"),
 		};
 
 		auto result = opaque_server_login_start(params);

--- a/cpp/react-native-opaque.cpp
+++ b/cpp/react-native-opaque.cpp
@@ -91,7 +91,7 @@ namespace NativeOpaque
 			.password = getProp(rt, obj, "password").utf8(rt),
 			.registration_response = getProp(rt, obj, "registrationResponse").utf8(rt),
 			.client_registration = getProp(rt, obj, "clientRegistration").utf8(rt),
-			.client_identifier = getProp(rt, obj, "clientIdentifier").utf8(rt),
+			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
 			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
 		};
 
@@ -119,7 +119,7 @@ namespace NativeOpaque
 			.client_login = getProp(rt, obj, "clientLogin").utf8(rt),
 			.credential_response = getProp(rt, obj, "credentialResponse").utf8(rt),
 			.password = getProp(rt, obj, "password").utf8(rt),
-			.client_identifier = getProp(rt, obj, "clientIdentifier").utf8(rt),
+			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
 			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
 		};
 		auto result = opaque_client_login_finish(params);
@@ -146,7 +146,7 @@ namespace NativeOpaque
 		auto obj = input.asObject(rt);
 		struct OpaqueServerRegistrationStartParams params = {
 			.server_setup = getProp(rt, obj, "serverSetup").utf8(rt),
-			.client_identifier = getProp(rt, obj, "clientIdentifier").utf8(rt),
+			.credential_identifier = getProp(rt, obj, "credentialIdentifier").utf8(rt),
 			.registration_request = getProp(rt, obj, "registrationRequest").utf8(rt),
 		};
 		auto result = opaque_server_registration_start(params);
@@ -167,7 +167,8 @@ namespace NativeOpaque
 			.server_setup = getProp(rt, obj, "serverSetup").utf8(rt),
 			.password_file = getOptional(rt, obj, "passwordFile"),
 			.credential_request = getProp(rt, obj, "credentialRequest").utf8(rt),
-			.client_identifier = getProp(rt, obj, "clientIdentifier").utf8(rt),
+			.credential_identifier = getProp(rt, obj, "credentialIdentifier").utf8(rt),
+			.client_identifier = getOptional(rt, obj, "clientIdentifier"),
 			.server_identifier = getOptional(rt, obj, "serverIdentifier"),
 		};
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,7 +20,7 @@ async function request(method: string, url: string, body: any = undefined) {
 
 async function register(
   host: string,
-  clientIdentifier: string,
+  credentialIdentifier: string,
   password: string
 ) {
   const { clientRegistration, registrationRequest } =
@@ -29,39 +29,41 @@ async function register(
     'POST',
     `${host}/register/start`,
     {
-      clientIdentifier,
+      credentialIdentifier,
       registrationRequest,
     }
   ).then((res) => res.json());
 
   console.log('registrationResponse', registrationResponse);
   const { registrationUpload } = opaque.clientRegistrationFinish({
-    clientIdentifier,
     clientRegistration,
     registrationResponse,
     password,
   });
 
   const res = await request('POST', `${host}/register/finish`, {
-    clientIdentifier,
+    credentialIdentifier,
     registrationUpload,
   });
   console.log('finish successful', res.ok);
   return res.ok;
 }
 
-async function login(host: string, clientIdentifier: string, password: string) {
+async function login(
+  host: string,
+  credentialIdentifier: string,
+  password: string
+) {
   const { clientLogin, credentialRequest } = opaque.clientLoginStart(password);
 
   const { credentialResponse } = await request('POST', `${host}/login/start`, {
-    clientIdentifier,
+    credentialIdentifier,
     credentialRequest,
   }).then((res) => res.json());
 
   const loginResult = opaque.clientLoginFinish({
     clientLogin,
     credentialResponse,
-    clientIdentifier,
     password,
   });
 
@@ -70,7 +72,7 @@ async function login(host: string, clientIdentifier: string, password: string) {
   }
   const { sessionKey, credentialFinalization } = loginResult;
   const res = await request('POST', `${host}/login/finish`, {
-    clientIdentifier,
+    credentialIdentifier,
     credentialFinalization,
   });
   return res.ok ? sessionKey : null;
@@ -194,7 +196,7 @@ function runFullServerClientFlow(
   const registrationResponse = opaque.serverRegistrationStart({
     serverSetup,
     registrationRequest,
-    clientIdentifier: username,
+    credentialIdentifier: username,
   });
 
   console.log({ registrationResponse });
@@ -207,7 +209,6 @@ function runFullServerClientFlow(
     exportKey: clientRegExportKey,
     serverStaticPublicKey: clientRegServerStaticPublicKey,
   } = opaque.clientRegistrationFinish({
-    clientIdentifier: username,
     password,
     clientRegistration,
     registrationResponse,
@@ -233,7 +234,7 @@ function runFullServerClientFlow(
   console.log('serverLoginStart');
   console.log('----------------');
   const { credentialResponse, serverLogin } = opaque.serverLoginStart({
-    clientIdentifier: username,
+    credentialIdentifier: username,
     passwordFile,
     serverSetup,
     credentialRequest,
@@ -245,7 +246,6 @@ function runFullServerClientFlow(
   console.log('clientLoginFinish');
   console.log('-----------------');
   const loginResult = opaque.clientLoginFinish({
-    clientIdentifier: username,
     clientLogin,
     credentialResponse,
     password,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,11 @@ if (Opaque && typeof Opaque.install === 'function') {
   console.warn('Opaque.install not a function');
 }
 
+type CustomIdentifiers = {
+  client?: string;
+  server?: string;
+};
+
 type ClientRegistrationStartResult = {
   clientRegistration: string;
   registrationRequest: string;
@@ -26,8 +31,7 @@ type ClientRegistrationFinishParams = {
   password: string;
   registrationResponse: string;
   clientRegistration: string;
-  clientIdentifier?: string;
-  serverIdentifier?: string;
+  identifiers?: CustomIdentifiers;
 };
 
 type ClientRegistrationFinishResult = {
@@ -57,8 +61,7 @@ type ClientLoginFinishParams = {
   clientLogin: string;
   credentialResponse: string;
   password: string;
-  clientIdentifier?: string;
-  serverIdentifier?: string;
+  identifiers?: CustomIdentifiers;
 };
 
 type ClientLoginFinishResult = {
@@ -99,8 +102,7 @@ type ServerLoginStartParams = {
   passwordFile: string | undefined;
   credentialRequest: string;
   credentialIdentifier: string;
-  clientIdentifier?: string;
-  serverIdentifier?: string;
+  identifiers?: CustomIdentifiers;
 };
 
 type ServerLoginStartResult = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ type ClientRegistrationFinishParams = {
   password: string;
   registrationResponse: string;
   clientRegistration: string;
-  clientIdentifier: string;
+  clientIdentifier?: string;
   serverIdentifier?: string;
 };
 
@@ -57,7 +57,7 @@ type ClientLoginFinishParams = {
   clientLogin: string;
   credentialResponse: string;
   password: string;
-  clientIdentifier: string;
+  clientIdentifier?: string;
   serverIdentifier?: string;
 };
 
@@ -80,7 +80,7 @@ export const serverSetup = opaque_serverSetup;
 
 type ServerRegistrationStartParams = {
   serverSetup: string;
-  clientIdentifier: string;
+  credentialIdentifier: string;
   registrationRequest: string;
 };
 
@@ -98,7 +98,8 @@ type ServerLoginStartParams = {
   serverSetup: string;
   passwordFile: string | undefined;
   credentialRequest: string;
-  clientIdentifier: string;
+  credentialIdentifier: string;
+  clientIdentifier?: string;
   serverIdentifier?: string;
 };
 


### PR DESCRIPTION
- Add required `credentialIdentifier` property (_username_ in opaque-ke example login code) distinct from `clientIdentifier`
- Make `clientIdentifier` optional and remove where it was used as `credentialIdentifier`
- Change the JS/TS interface to pass both client and server custom identifiers as optional nested object