### PR TITLE
Enable full link-time optimization for rust build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.release]
+lto = true
+
 [features]
 default = []
 p256 = ["dep:p256"]


### PR DESCRIPTION
This should reduce the size of the final libraries from between 19-24M (per target arch) to 4.4M-8.1M.